### PR TITLE
changed Address to Location, etc

### DIFF
--- a/Geocoder.js.gs
+++ b/Geocoder.js.gs
@@ -17,7 +17,7 @@ function geocode(source) {
   if (cells.getNumColumns() != 6) {
     ui.alert(
       'Warning',
-      'You must select 6 columns: Address, Latitude, Longitude, Found Address, Match Quality, Source',
+      'You must select 6 columns: Location, Latitude, Longitude, Found, Quality, Source',
       ui.ButtonSet.OK
     );
     return;


### PR DESCRIPTION
"Address" is too specific, since people sometimes need to geolocate "locations"

I also changed this in the Google Sheet
6 columns: Location, Latitude, Longitude, Found, Quality, Source